### PR TITLE
Drop 'lodash', update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generaterr",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A simple dependency free custom error generator for node.js",
   "main": "index.js",
   "repository": "git://github.com/saintedlama/generaterr.git",
@@ -12,9 +12,9 @@
     "custom-error"
   ],
   "devDependencies": {
-    "chai": "^3.4.1",
-    "mocha": "^2.4.4",
-    "shelljs": "^0.6.0"
+    "chai": "^3.5.0",
+    "mocha": "^2.5.3",
+    "shelljs": "^0.7.0"
   },
   "scripts": {
     "test": "mocha -R spec test/",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   "scripts": {
     "test": "mocha -R spec test/",
     "cover": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec"
-  },
-  "dependencies": {
-    "lodash": "^4.0.1"
   }
 }


### PR DESCRIPTION
'lodash' is not used throughout the module but still loaded on package installation.